### PR TITLE
Add inclusion path type not requiring an index or direction

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -80,7 +80,10 @@ PathEntry = [
 ]
 ```
 
+For some tree algorithms, like QLDB, the direction is derived from the hashes themselves and both the index and direction can be left out in the path:
+
 ```c
+; TODO: find a better name for this
 UndirectionalInclusionPath = [+ bstr]
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -81,7 +81,11 @@ PathEntry = [
 ```
 
 ```c
-InclusionPath = IndexAwareInclusionPath / IndexUnawareInclusionPath
+UndirectionalInclusionPath = [+ bstr]
+```
+
+```c
+InclusionPath = IndexAwareInclusionPath / IndexUnawareInclusionPath / UndirectionalInclusionPath
 ```
 
 Note: Including the tree size and leaf index may not be appropriate in certain privacy-focused applications as an attacker may be able to derive private information from them.


### PR DESCRIPTION
For example, used in QLDB-style trees. I couldn't think of a good name for this type. Any suggestions are welcome. Maybe something like `RawInclusionPath`?