### PR TITLE
Add CBOR tags for inclusion path types and encoding leftness as bitvector

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -64,16 +64,16 @@ Note: The payload is just the raw Merkle tree root hash (and not some wrapper st
 If the tree size and leaf index is known, then a compact inclusion path variant can be used:
 
 ```c
-IndexAwareInclusionPath = [
+IndexAwareInclusionPath = #6.1234([
     leaf_index: int
     hashes: [+ bstr]
-]
+])
 ```
 
 Otherwise, the direction for each path step must be included:
 
 ```c
-IndexUnawareInclusionPath = [+ PathEntry]
+IndexUnawareInclusionPath = #6.1235([+ PathEntry])
 PathEntry = [
     left: bool
     hash: bstr
@@ -84,7 +84,7 @@ For some tree algorithms, like QLDB, the direction is derived from the hashes th
 
 ```c
 ; TODO: find a better name for this
-UndirectionalInclusionPath = [+ bstr]
+UndirectionalInclusionPath = #6.1236([+ bstr])
 ```
 
 ```c
@@ -94,8 +94,6 @@ InclusionPath = IndexAwareInclusionPath / IndexUnawareInclusionPath / Undirectio
 Note: Including the tree size and leaf index may not be appropriate in certain privacy-focused applications as an attacker may be able to derive private information from them.
 
 TODO: Should leaf index be part of inclusion path (IndexAwareInclusionPath) or outside?
-
-TODO: How are the two types of inclusion paths distinguished?
 
 TODO: Define root computation algorithm for each inclusion path type
 

--- a/specification.md
+++ b/specification.md
@@ -73,11 +73,10 @@ IndexAwareInclusionPath = #6.1234([
 Otherwise, the direction for each path step must be included:
 
 ```c
-IndexUnawareInclusionPath = #6.1235([+ PathEntry])
-PathEntry = [
-    left: bool
-    hash: bstr
-]
+IndexUnawareInclusionPath = #6.1235([
+    hashes: [+ bstr]
+    left: int  ; bit vector
+])
 ```
 
 For some tree algorithms, like QLDB, the direction is derived from the hashes themselves and both the index and direction can be left out in the path:


### PR DESCRIPTION
This mirrors #12.