### PR TITLE
Change encoding of `SignedMerkleTreeProof` and extend implementation

### DIFF
--- a/python/merkle_proofs/proofs.py
+++ b/python/merkle_proofs/proofs.py
@@ -1,28 +1,25 @@
+from typing import Optional
+from dataclasses import dataclass
 import cbor2
 
-import merkle_proofs.tree_algorithms as ta
+@dataclass
+class SignedMerkleTreeProof:
+    smtr: bytes
+    inclusion_path: bytes
+    extra_data: Optional[bytes]
+    payload: bytes
 
-def encode_proof(smtr: bytes, inclusion_path: bytes, entry: ta.Entry):
-    detached_smtr = detach_cose_sign1_payload(smtr)
-    proof = [
-        detached_smtr,
-        inclusion_path,
-        entry.extra_data,
-        entry.payload,
-    ]
-    return cbor2.dumps(proof)    
+    def encode(self):
+        proof = [
+            self.smtr,
+            self.inclusion_path,
+            self.extra_data,
+            self.payload,
+        ]
+        return cbor2.dumps(proof)
 
+    @classmethod
+    def decode(cls, encoded_proof):
+        proof = cbor2.loads(encoded_proof)
+        return cls(*proof)
 
-def detach_cose_sign1_payload(msg):
-    # pycose doesn't support detached payloads, so we have to do it manually.
-    decoded = cbor2.loads(msg)
-    assert decoded.tag == 18 # COSE_Sign1
-    [phdr, uhdr, _, signature] = decoded.value
-
-    detached = cbor2.CBORTag(18, [
-        phdr,
-        uhdr,
-        None,
-        signature,
-    ])
-    return cbor2.dumps(detached)

--- a/python/merkle_proofs/tree_algorithms.py
+++ b/python/merkle_proofs/tree_algorithms.py
@@ -15,8 +15,19 @@ class Entry:
     extra_data: Optional[bytes]
 
 
+class InclusionPath(ABC):
+    @abstractmethod
+    def encode(self) -> bytes:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def decode(cls, data: bytes) -> 'InclusionPath':
+        pass
+
+
 @dataclass
-class IndexAwareInclusionPath:
+class IndexAwareInclusionPath(InclusionPath):
     TAG = 1234
 
     index: int
@@ -44,7 +55,7 @@ class IndexAwareInclusionPath:
 
 
 @dataclass
-class IndexUnawareInclusionPath:
+class IndexUnawareInclusionPath(InclusionPath):
     TAG = 1235
 
     hashes: List[bytes]
@@ -82,7 +93,7 @@ class IndexUnawareInclusionPath:
 
 
 @dataclass
-class UndirectionalInclusionPath:
+class UndirectionalInclusionPath(InclusionPath):
     TAG = 1236
 
     hashes: List[bytes]

--- a/python/tests/test_proofs.py
+++ b/python/tests/test_proofs.py
@@ -1,0 +1,32 @@
+import cbor2
+import pycose
+
+import merkle_proofs.tree_algorithms as ta
+from merkle_proofs.smtr import sign_tree_root
+from merkle_proofs.proofs import SignedMerkleTreeProof
+
+def test_signed_merkle_tree_proof_encoding():
+    tree_alg = ta.RFC6962Sha256TreeAlgorithm()
+    entries = [ta.Entry(f'entry_{i}'.encode(), None) for i in range(6)]
+    entry_hashes = [tree_alg.hash_entry(e) for e in entries]
+    root = tree_alg.compute_root_from_hashed_entries(entry_hashes)
+    
+    key = pycose.keys.EC2Key.generate_key('P_256')
+
+    smtr = sign_tree_root(root, tree_alg, key, "ES256", tree_size=len(entries), detached=True)
+
+    entry_idx = 0
+    inclusion_path = tree_alg.generate_index_aware_inclusion_path(entry_hashes, entry_idx).encode()
+
+    smtp = SignedMerkleTreeProof(
+        smtr,
+        inclusion_path,
+        entries[entry_idx].extra_data,
+        entries[entry_idx].payload).encode()
+
+    decoded = SignedMerkleTreeProof.decode(smtp)
+    assert decoded.smtr == smtr
+    assert decoded.inclusion_path == inclusion_path
+    assert decoded.extra_data == entries[entry_idx].extra_data
+    assert decoded.payload == entries[entry_idx].payload
+    

--- a/specification.md
+++ b/specification.md
@@ -106,8 +106,8 @@ A signed Merkle tree proof is a CBOR array containing a signed tree root, an inc
 
 ```c
 SignedMerkleTreeProof = [
-  signed_tree_root: COSE_Sign1_Tagged (detached)
-  inclusion_path: InclusionPath
+  signed_tree_root: bstr .cbor COSE_Sign1_Tagged  ; detached
+  inclusion_path: bstr .cbor InclusionPath
   extra_data: bstr / nil
   payload: bstr
 ]


### PR DESCRIPTION
bstr-wrapping the SMTR and the inclusion path makes it easier to write libraries. Especially COSE libraries normally expect a bytestring instead of a parsed CBOR structure.